### PR TITLE
use piston endpoint for languages rather than hardcoding them.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -71,15 +71,8 @@ func init() {
 			Msg("GUILD_ID not found in .env file, registering commands globally.")
 	}
 
-	// Log the languages and environment.
-	i := 0
-	for l := range languageMappings {
-		languages[i] = l
-		i++
-	}
-
 	log.Debug().
-		Strs("languages", languages).
+		Strs("languages", *languages).
 		Str("env_file", DOTENV).
 		Str("token", TOKEN[:10]+strings.Repeat("*", len(TOKEN)-10)).
 		Str("piston_url", PISTON_URL).
@@ -160,7 +153,7 @@ func main() {
 	dg.Close()
 }
 
-var languages = make([]string, len(languageMappings))
+var languages = GetLanguages()
 
 // Array of all available languages as well as their markdown codes.
 var languageMappings = map[string][]string{
@@ -436,7 +429,7 @@ var (
 					Str("language", lang).
 					Msg("Language found from options.")
 
-				if !stringInSlice(lang, languages) {
+				if !stringInSlice(lang, *languages) {
 					_, err := s.FollowupMessageCreate(s.State.User.ID, i.Interaction, false, &discordgo.WebhookParams{
 						Content: fmt.Sprintf("Language %v is not supported. Supported languages are: %v", lang, languages),
 					})
@@ -528,7 +521,7 @@ var (
 									},
 									{
 										Name:  "Supported Languages",
-										Value: strings.Join(languages, ", "),
+										Value: strings.Join(*languages, ", "),
 									},
 								},
 							},

--- a/exec.go
+++ b/exec.go
@@ -6,10 +6,9 @@ import (
 	piston "github.com/milindmadhukar/go-piston"
 )
 
-var httpClient = http.DefaultClient
-var client = piston.New("", httpClient, PISTON_URL)
-
 func Exec(lang string, version string, code string) (string, error) {
+	httpClient := http.DefaultClient
+	client := piston.New("", httpClient, PISTON_URL)
 	output, err := client.Execute(lang, version,
 		[]piston.Code{
 			{
@@ -23,7 +22,12 @@ func Exec(lang string, version string, code string) (string, error) {
 	return output.GetOutput(), nil
 }
 
-func GetLanguages() *[]string {
-	languages := client.GetLanguages()
-	return languages
+func GetRuntimes() *piston.Runtimes {
+	httpClient := http.DefaultClient
+	client := piston.New("", httpClient, PISTON_URL)
+	runtimes, err := client.GetRuntimes()
+	if err != nil {
+		return nil
+	}
+	return runtimes
 }

--- a/exec.go
+++ b/exec.go
@@ -6,22 +6,24 @@ import (
 	piston "github.com/milindmadhukar/go-piston"
 )
 
+var httpClient = http.DefaultClient
+var client = piston.New("", httpClient, PISTON_URL)
+
 func Exec(lang string, version string, code string) (string, error) {
-	httpClient := http.DefaultClient
-	client := piston.New("",
-		httpClient,
-		PISTON_URL,
-	)
 	output, err := client.Execute(lang, version,
 		[]piston.Code{
 			{
 				Content: code,
 			},
 		},
-		// piston.Stdin("hello world"), // Passing input as "hello world".
 	)
 	if err != nil {
 		return "", err
 	}
 	return output.GetOutput(), nil
+}
+
+func GetLanguages() *[]string {
+	languages := client.GetLanguages()
+	return languages
 }


### PR DESCRIPTION
Closes #4.

Unfortunately not possible (?) for the mappings as they require hardcoded values which I have retrieved from [pygments](https://pygments.org/docs/lexers/).

If either @wozeparrot or @Nathan13888 figure out a way to do this, please lmk :)