### PR TITLE
Switch to string formatting

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -101,7 +101,7 @@ func init() {
 
 func main() {
 	// Create a new Discord session using the provided bot token.
-	dg, err := discordgo.New("Bot " + TOKEN)
+	dg, err := discordgo.New(fmt.Sprintf("Bot %s", TOKEN))
 	if err != nil {
 		log.Fatal().
 			Err(err).


### PR DESCRIPTION
I have changed the formation of the bot token header to use string formatting, rather than using string concatenation.